### PR TITLE
readme.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 Madrona:<br>A GPU-Accelerated Game Engine for Batch Simulation
 ===========================================================
 
-Madrona is a prototype game engine for building high-throughput GPU-accelerated _batch simulators_ that execute thousands of virtual worlds concurrently. By leveraging parallelism between and within worlds, simulators built on Madrona are able to execute on the GPU at millions of frames per second, enabling high performance sample generation for training agents using reinforcement learning, or other tasks requiring a high performance simulator in the loop. At its core, Madrona is built around the Entity Component System (ECS) architecture, which the engine uses to provide high-performance C++ interfaces for implementing custom logic and state that the engine can can automatically map to parallel batch execution on the GPU.
+Madrona is a prototype game engine for creating high-throughput, GPU-accelerated _batch simulators_: simulators that efficiently run thousands of virtual environment instances efficiently on a single GPU or CPU. By sharing game state data structures across environments and leveraging both inter- and intra-envrionment parallelism, simulators built using Madrona can achieve throughputs of tens of millions of aggregate world simulation steps per second on a single GPU.  This capability is useful for rapid AI agent training (e.g., via reinforcement learning), or for any task that requires high-performance world simulator "in-the-loop".
+
+Madrona is built around the [Entity Component System](https://github.com/SanderMertens/ecs-faq) (ECS) architecture. It exposes high-performance C++ interfaces for games to implement custom logic and state that Madrona automatically maps to parallel batch execution on the GPU. Implementing a new game in Madrona will require the author to think in terms of implicitly data-parallel ECS concepts, but does not require knowledge of GPU programming or GPU performance optimization. 
 
 **Features**:
 * Fully GPU-driven batch ECS implementation for high-throughput execution.
-* CPU Backend for debugging & visualization. Simulators can execute on GPU or CPU with no code changes!
-* Export ECS Simulation State as PyTorch tensors for efficient interop with learning code.
-* (Optional) XPBD rigid body physics for basic 3D collision & contact support.
-* (Optional) Simple 3D renderer for visualizing agent behaviors or debugging.
+* CPU backend for debugging and visualization. Simulators can execute on GPU or CPU with no code changes.
+* Export ECS simulation state as PyTorch tensors for efficient interopability with learning code.
+* (Optional) XPBD rigid body physics for basic 3D collision and contact support.
+* (Optional) Simple 3D renderer for visualizing agent behaviors and debugging.
+
+**Disclaimer**: The Madrona engine is a research code base. While we hope to attract interested users / collaborators with this release, there will be missing features / documentation / bugs, as well as breaking API changes as we continue to develop the engine. Please post any issues you find on this github repo.
+
+# Technical Paper
 
 For more background and technical details, please read our paper: [_An Extensible, Data-Oriented Architecture for High-Performance, Many-World Simulation_](https://madrona-engine.github.io/shacklett_siggraph23.pdf), published in Transactions on Graphics / SIGGRAPH 2023.
 
-**Disclaimer**: The Madrona engine is an early-stage research codebase. While we hope to attract interested users / collaborators with this release, there will be missing features / documentation / bugs, as well as breaking API changes as we continue to develop the engine. Please post any issues you find on this github repo.
+This Shacklett et al. paper focuses on the design and implementation of Madrona. For general background and tutorials on ECS programming abstractions and the motivation for the ECS design pattern's use in games, we recommend Sander Martens' excellent [ECS FAQ](https://github.com/SanderMertens/ecs-faq).
+
+# Example Simulators Created Using Madrona
+
+* [Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example)
+  * A simple 3D environment that demonstrates the use of Madrona's ECS APIs, as well as physics and rendering functionality, via a simple task where agents must learn to press buttons and pull blocks to advance through a series of rooms.
+* [Overcooked AI](xxx)
+  * A port of the popular Overcooked AI environment used for multi-agent learning research.
+* [Hide And Seek](xxx)
+  * A port of OpenAI's "hide and seek" environment from the paper [Emergent Tool Use from Mult-Agent Autocurricula](https://openai.com/research/emergent-tool-use)
+* [Hanabi](xxx)
+  * The card game.
+* [Cartpole]
+  * A simple hello world environment.
 
 Dependencies
 ------------
@@ -35,22 +54,22 @@ Dependencies
 * CUDA 12.1 or newer (+ appropriate NVIDIA drivers)
 * **Linux** (CUDA on Windows lacks certain unified memory features that Madrona requires)
 
-These dependencies are needed for the GPU backend. If they're not present, Madrona's GPU backend will be disabled, but you can still use the CPU backend.
+These dependencies are needed for the GPU backend. If they are not present, Madrona's GPU backend will be disabled, but you can still use the CPU backend.
 
 Getting Started
 ---------------
 
 Madrona is intended to be integrated as a library / submodule of simulators built on top of the engine. Therefore, you should start with one of our example simulators, rather than trying to build this repo directly.
 
-As a starting point for learning how to use the engine, we recommend the [Madrona3DExample project](https://github.com/shacklettbp/madrona_3d_example). This is a simple 3D environment that demonstrates the use of Madrona's ECS APIs, as well as physics and rendering functionality, with a simple task where agents must learn to press buttons and pull blocks to advance through a series of rooms.
+As a starting point for learning how to use the engine, we recommend the [Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example) project. This is a simple 3D environment that demonstrates the use of Madrona's ECS APIs, as well as physics and rendering functionality, via a simple task where agents must learn to press buttons and pull blocks to advance through a series of rooms.
 
-For more ML-focused users interested in training agents at high speed, check out the [Madrona RL Environments repo](https://github.com/bsarkar321/madrona_rl_envs) that contains an Overcooked AI implementation where you can train agents in 2 minutes using Google Colab, as well as Hanabi and Cartpole implementations.
+For ML-focused users interested in training agents at high speed, we recommend you check out the [Madrona RL Environments repo](https://github.com/bsarkar321/madrona_rl_envs) that contains an Overcooked AI implementation where you can train agents in two minutes using Google Colab, as well as Hanabi and Cartpole implementations.
 
-If you're interested in building a new simulator on top of Madrona, we recommend forking one of the above projects and adding your own functionality, or forking the [Madrona GridWorld repo](https://github.com/shacklettbp/madrona_gridworld) for an example with very little existing logic to get in your way. Basing your work on one of these repositories will ensure that the CMake build system and python bindings are setup correctly.
+If you're interested in authoring a new simulator on top of Madrona, we recommend forking one of the above projects and adding your own functionality, or forking the [Madrona GridWorld repo](https://github.com/shacklettbp/madrona_gridworld) as an example with very little existing logic to get in your way. Basing your work on one of these repositories will ensure that the CMake build system and python bindings are setup correctly.
 
 **Building:**
 
-Instructions on building and testing the Madrona3DExample simulator are included below for Linux and MacOS:
+Instructions on building and testing the [Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example) simulator are included below for Linux and MacOS:
 ```bash
 git clone --recursive https://github.com/shacklettbp/madrona_3d_example.git
 cd madrona_3d_example
@@ -66,7 +85,7 @@ You can then view the environment by running:
 ./build/viewer
 ```
 
-Refer to the simulator's github page for further context / instructions on how to train agents.
+Please refer to the Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example)simulator's github page for further context / instructions on how to train agents.
 
 **Windows Instructions**:
 Windows users should clone the repository as above, and then open the root of the cloned repo in Visual Studio and build with the integrated CMake support. 
@@ -77,7 +96,8 @@ pip install -e . -Cpackages.madrona_3d_example.ext-out-dir=out/build/Release-x64
 
 Code Organization
 -----------------
-As mentioned above, we recommend starting with the [Madrona3DExample project](https://github.com/shacklettbp/madrona_3d_example) for learning how to use Madrona's ECS APIs, as documentation within Madrona itself is still fairly minimal.
+
+We recommend starting with the [Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example) project for learning how to use Madrona's ECS APIs, as documentation within Madrona itself is still fairly minimal.
 
 Nevertheless, the following files provide good starting points to start diving into the Madrona codebase:
 
@@ -85,20 +105,23 @@ The `Context` class: [`include/madrona/context.hpp`](https://github.com/shacklet
 
 The `ECSRegistry` class: [`include/madrona/registry.hpp`](https://github.com/shacklettbp/madrona/blob/main/include/madrona/registry.hpp) is where user code registers all the ECS Components and Archetypes that will be used during the simulation. Note that Madrona requires all the used archetypes to be declared up front -- unlike other ECS engines adding and removing components dynamically from entities is not currently supported.
 
-The `TaskGraphBuilder` class: [`include/madrona/taskgraph_builder.hpp`](https://github.com/shacklettbp/madrona/blob/main/include/madrona/taskgraph_builder.hpp) includes the interface for building the taskgraph that will be executed to step the simulation across all worlds.
+The `TaskGraphBuilder` class: [`include/madrona/taskgraph_builder.hpp`](https://github.com/shacklettbp/madrona/blob/main/include/madrona/taskgraph_builder.hpp) includes the interface for building the task graph that will be executed to step the simulation across all worlds.
 
 The `MWCudaExecutor` class: [`include/madrona/mw_gpu.hpp`](https://github.com/shacklettbp/madrona/blob/main/include/madrona/mw_gpu.hpp) is the entry point for the GPU backend.  
+
 The `TaskGraphExecutor` class: [`include/madrona/mw_cpu.hpp`](https://github.com/shacklettbp/madrona/blob/main/include/madrona/mw_gpu.hpp) is the entry point for the CPU backend.
 
 Citation
 --------
-If you use Madrona in a research project, please cite our SIGGRAPH paper!
+If you use Madrona in a research project, please cite our SIGGRAPH 2023 paper:
 
 ```
 @article{shacklett23madrona,
     title   = {An Extensible, Data-Oriented Architecture for High-Performance, Many-World Simulation},
     author  = {Brennan Shacklett and Luc Guy Rosenzweig and Zhiqiang Xie and Bidipta Sarkar and Andrew Szot and Erik Wijmans and Vladlen Koltun and Dhruv Batra and Kayvon Fatahalian},
-    journal = {Transactions on Graphics},
+    journal = {ACM Trans. Graph.},
+    volume = {42},
+    number = {4},
     year    = {2023}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Madrona:<br>A GPU-Accelerated Game Engine for Batch Simulation
 ===========================================================
 
-Madrona is a prototype game engine for creating high-throughput, GPU-accelerated _batch simulators_: simulators that efficiently run thousands of virtual environment instances efficiently on a single GPU or CPU. By sharing game state data structures across environments and leveraging both inter- and intra-envrionment parallelism, simulators built using Madrona can achieve throughputs of tens of millions of aggregate world simulation steps per second on a single GPU.  This capability is useful for rapid AI agent training (e.g., via reinforcement learning), or for any task that requires high-performance world simulator "in-the-loop".
+Madrona is a prototype game engine for creating high-throughput, GPU-accelerated _batch simulators_: simulators that efficiently run thousands of virtual environment instances efficiently on a single GPU or CPU. Simulators built using Madrona can realize throughputs of tens of millions of world simulation steps per second in aggregate on a single GPU. This capability is useful for high-performance AI agent training (e.g., via reinforcement learning), or for any task that requires a high-performance environment simulator tightly integrated "in-the-loop" of a broader application.
 
-Madrona is built around the [Entity Component System](https://github.com/SanderMertens/ecs-faq) (ECS) architecture. It exposes high-performance C++ interfaces for games to implement custom logic and state that Madrona automatically maps to parallel batch execution on the GPU. Implementing a new game in Madrona will require the author to think in terms of implicitly data-parallel ECS concepts, but does not require knowledge of GPU programming or GPU performance optimization. 
+Madrona uses an [Entity Component System](https://github.com/SanderMertens/ecs-faq) (ECS) architecture. __At this time Madrona exposes interfaces for games to implement custom logic and state in C++.__ Madrona automatically maps this logic to parallel batch execution on the GPU. Implementing a new game (or a new learning environment) in Madrona will require the author to express game logic using data-parallel ECS concepts, but it does not require a developer to have knowledge of GPU programming or GPU performance optimization. 
 
 **Features**:
 * Fully GPU-driven batch ECS implementation for high-throughput execution.
@@ -18,20 +18,20 @@ Madrona is built around the [Entity Component System](https://github.com/SanderM
 
 For more background and technical details, please read our paper: [_An Extensible, Data-Oriented Architecture for High-Performance, Many-World Simulation_](https://madrona-engine.github.io/shacklett_siggraph23.pdf), published in Transactions on Graphics / SIGGRAPH 2023.
 
-This Shacklett et al. paper focuses on the design and implementation of Madrona. For general background and tutorials on ECS programming abstractions and the motivation for the ECS design pattern's use in games, we recommend Sander Martens' excellent [ECS FAQ](https://github.com/SanderMertens/ecs-faq).
+For general background and tutorials on ECS programming abstractions and the motivation for the ECS design pattern's use in games, we recommend Sander Martens' excellent [ECS FAQ](https://github.com/SanderMertens/ecs-faq).
 
 # Example Simulators Created Using Madrona
 
 * [Madrona3DExample](https://github.com/shacklettbp/madrona_3d_example)
   * A simple 3D environment that demonstrates the use of Madrona's ECS APIs, as well as physics and rendering functionality, via a simple task where agents must learn to press buttons and pull blocks to advance through a series of rooms.
 * [Overcooked AI](xxx)
-  * A port of the popular Overcooked AI environment used for multi-agent learning research.
+  * The Overcooked AI environment used for multi-agent learning research. Check out this repo to a CoLab notebook that allows you to train overcooked agents that demonstrate optimal play in under a minute.
 * [Hide And Seek](xxx)
-  * A port of OpenAI's "hide and seek" environment from the paper [Emergent Tool Use from Mult-Agent Autocurricula](https://openai.com/research/emergent-tool-use)
+  * A port of OpenAI's "hide and seek" environment from the paper [Emergent Tool Use from Multi-Agent Autocurricula](https://openai.com/research/emergent-tool-use).
 * [Hanabi](xxx)
   * The card game.
-* [Cartpole]
-  * A simple hello world environment.
+* [Cartpole](xxx)
+  * The canonical RL training environment.
 
 Dependencies
 ------------


### PR DESCRIPTION
A bit of text wordsmithing in README.md

One notable change is that a list of example environments was created and moved early in the README.  

Also added links to general ECS documentation.

 