### PR TITLE
Add Environment Variable for Users to Configure the Device Heap Size Limit

### DIFF
--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -257,6 +257,7 @@ static void setCudaHeapSize()
     if (user_heap_size) {
         heap_size = strtol(user_heap_size,nullptr,10);
     }
+
     REQ_CUDA(cudaDeviceSetLimit(cudaLimitMallocHeapSize,
                                 heap_size));
 }

--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -255,7 +255,7 @@ static void setCudaHeapSize()
 
     char* user_heap_size = getenv("MADRONA_MWGPU_DEVICE_HEAP_SIZE");
     if (user_heap_size) {
-        heap_size = strtol(user_heap_size,nullptr,10);
+        heap_size = strtoul(user_heap_size,nullptr,10);
     }
 
     REQ_CUDA(cudaDeviceSetLimit(cudaLimitMallocHeapSize,

--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -251,8 +251,14 @@ namespace madrona {
 static void setCudaHeapSize()
 {
     // FIXME size limit for device side malloc:
+    size_t heap_size = 4ul*1024ul*1024ul*1024ul;
+
+    char* user_heap_size = getenv("MADRONA_MWGPU_DEVICE_HEAP_SIZE");
+    if (user_heap_size) {
+        heap_size = strtol(user_heap_size,nullptr,10);
+    }
     REQ_CUDA(cudaDeviceSetLimit(cudaLimitMallocHeapSize,
-                                4ul*1024ul*1024ul*1024ul));
+                                heap_size));
 }
 
 using HostChannel = mwGPU::madrona::mwGPU::HostChannel;


### PR DESCRIPTION
On systems with not enough GPU memory, the current settings will cause a CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES. This adds environment variable MADRONA_MWGPU_DEVICE_HEAP_SIZE so users can set the heap size.