### PR TITLE
Implemented Context::iterateQuery in both CPU and GPU backends

### DIFF
--- a/include/madrona/context.hpp
+++ b/include/madrona/context.hpp
@@ -94,7 +94,7 @@ public:
     // Iterate a query over all entities with the template components,
     // executing the lambda fn for each one.
     template <typename Fn, typename... ComponentTs>
-    inline void iterateQuery(const Query<ComponentTs...>& query, Fn&& fn);
+    inline void iterateQuery(const Query<ComponentTs...> &query, Fn &&fn);
 
 #ifdef MADRONA_MW_MODE
     // Get the current world's ID: [0, numWorlds - 1]

--- a/include/madrona/context.hpp
+++ b/include/madrona/context.hpp
@@ -85,6 +85,16 @@ public:
     // memory.
     inline void * tmpAlloc(uint64_t num_bytes);
 
+    // Create an ECS query matching the template components.
+    // Pass to iterateQuery to iterate over all entities with the template set of components.
+    template <typename... ComponentTs>
+    inline Query<ComponentTs...> query();
+
+    // Iterate a query over all entities with the template components,
+    // executing the lambda fn for each one.
+    template <typename Fn, typename... ComponentTs>
+    inline void iterateQuery(const Query<ComponentTs...>& query, Fn&& fn);
+
 #ifdef MADRONA_MW_MODE
     // Get the current world's ID: [0, numWorlds - 1]
     inline WorldID worldID() const;

--- a/include/madrona/context.hpp
+++ b/include/madrona/context.hpp
@@ -86,7 +86,8 @@ public:
     inline void * tmpAlloc(uint64_t num_bytes);
 
     // Create an ECS query matching the template components.
-    // Pass to iterateQuery to iterate over all entities with the template set of components.
+    // Pass to iterateQuery to iterate over all entities with the
+    // template set of components.
     template <typename... ComponentTs>
     inline Query<ComponentTs...> query();
 

--- a/include/madrona/context.inl
+++ b/include/madrona/context.inl
@@ -73,6 +73,19 @@ void * Context::tmpAlloc(uint64_t num_bytes)
     return state_mgr_->tmpAlloc(MADRONA_MW_COND(cur_world_id_,) num_bytes);
 }
 
+template <typename... ComponentTs>
+Query<ComponentTs...> Context::query()
+{
+    return state_mgr_->query<ComponentTs...>();
+}
+
+template <typename Fn, typename... ComponentTs>
+inline void Context::iterateQuery(const Query<ComponentTs...>& query, Fn&& fn)
+{
+    state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_, ) query,
+        std::forward<Fn>(fn));
+}
+
 #ifdef MADRONA_USE_JOB_SYSTEM
 JobID Context::currentJobID() const
 {
@@ -192,7 +205,8 @@ Query<ComponentTs...> Context::query()
 template <typename... ComponentTs, typename Fn>
 void Context::forEach(const Query<ComponentTs...> &query, Fn &&fn)
 {
-    state_mgr_->iterateEntities(MADRONA_MW_COND(cur_world_id_,) query,
+    // ZM: previously iterateEntities.
+    state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_,) query,
                                 std::forward<Fn>(fn));
 }
 

--- a/include/madrona/context.inl
+++ b/include/madrona/context.inl
@@ -205,7 +205,6 @@ Query<ComponentTs...> Context::query()
 template <typename... ComponentTs, typename Fn>
 void Context::forEach(const Query<ComponentTs...> &query, Fn &&fn)
 {
-    // ZM: previously iterateEntities.
     state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_,) query,
                                 std::forward<Fn>(fn));
 }

--- a/include/madrona/context.inl
+++ b/include/madrona/context.inl
@@ -80,7 +80,7 @@ Query<ComponentTs...> Context::query()
 }
 
 template <typename Fn, typename... ComponentTs>
-inline void Context::iterateQuery(const Query<ComponentTs...>& query, Fn&& fn)
+inline void Context::iterateQuery(const Query<ComponentTs...> &query, Fn &&fn)
 {
     state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_, ) query,
         std::forward<Fn>(fn));

--- a/include/madrona/state.hpp
+++ b/include/madrona/state.hpp
@@ -176,8 +176,9 @@ public:
     inline void iterateArchetypes(MADRONA_MW_COND(uint32_t world_id,)
                                   const Query<ComponentTs...> &query, Fn &&fn);
 
+    // ZM previously iterateEntities.
     template <typename... ComponentTs, typename Fn>
-    inline void iterateEntities(MADRONA_MW_COND(uint32_t world_id,)
+    inline void iterateQuery(MADRONA_MW_COND(uint32_t world_id,)
                                 const Query<ComponentTs...> &query, Fn &&fn);
 
     Transaction makeTransaction();

--- a/include/madrona/state.hpp
+++ b/include/madrona/state.hpp
@@ -165,7 +165,6 @@ public:
     inline void iterateArchetypes(MADRONA_MW_COND(uint32_t world_id,)
                                   const Query<ComponentTs...> &query, Fn &&fn);
 
-    // ZM previously iterateEntities.
     template <typename... ComponentTs, typename Fn>
     inline void iterateQuery(MADRONA_MW_COND(uint32_t world_id,)
                                 const Query<ComponentTs...> &query, Fn &&fn);

--- a/include/madrona/state.inl
+++ b/include/madrona/state.inl
@@ -299,6 +299,7 @@ Query<ComponentTs...> StateManager::query()
 
     QueryRef *ref = &Query<ComponentTs...>::ref_;
 
+    // Deduplication: check to see if the query templated on these components has already been created.
     if (ref->numReferences.load_acquire() == 0) {
         makeQuery(component_ids.data(), component_ids.size(), ref);
     }
@@ -347,7 +348,7 @@ void StateManager::iterateArchetypesImpl(MADRONA_MW_COND(uint32_t world_id,)
 }
 
 template <typename... ComponentTs, typename Fn>
-void StateManager::iterateEntities(MADRONA_MW_COND(uint32_t world_id,)
+void StateManager::iterateQuery(MADRONA_MW_COND(uint32_t world_id,)
                                    const Query<ComponentTs...> &query, Fn &&fn)
 {
     iterateArchetypes(MADRONA_MW_COND(world_id,) query, 

--- a/include/madrona/state.inl
+++ b/include/madrona/state.inl
@@ -328,7 +328,7 @@ Query<ComponentTs...> StateManager::query()
 
     QueryRef *ref = &Query<ComponentTs...>::ref_;
 
-    // Deduplication: check to see if the query templated on these components has already been created.
+    // If necessary, create the query templated on the passed in ComponentTs.
     if (ref->numReferences.load_acquire() == 0) {
         makeQuery(component_ids.data(), component_ids.size(), ref);
     }

--- a/include/madrona/taskgraph.inl
+++ b/include/madrona/taskgraph.inl
@@ -14,7 +14,8 @@ void TaskGraph::iterateQuery(ContextT &ctx,
                              Query<ComponentTs...> &query,
                              Fn &&fn)
 {
-    state_mgr_->iterateEntities(MADRONA_MW_COND(cur_world_id_,) query,
+    // Interesting, this is how you do argument forwarding of a general lambda.
+    state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_,) query,
         [&](auto &...refs) {
             fn(ctx, refs...);
         });

--- a/include/madrona/taskgraph.inl
+++ b/include/madrona/taskgraph.inl
@@ -14,7 +14,6 @@ void TaskGraph::iterateQuery(ContextT &ctx,
                              Query<ComponentTs...> &query,
                              Fn &&fn)
 {
-    // Interesting, this is how you do argument forwarding of a general lambda.
     state_mgr_->iterateQuery(MADRONA_MW_COND(cur_world_id_,) query,
         [&](auto &...refs) {
             fn(ctx, refs...);

--- a/src/mw/device/include/madrona/context.hpp
+++ b/src/mw/device/include/madrona/context.hpp
@@ -56,7 +56,7 @@ public:
     inline Query<ComponentTs...> query();
 
     template <typename... ComponentTs, typename Fn>
-    inline void iterateQuery(Query<ComponentTs...> &query, Fn&& fn);
+    inline void iterateQuery(Query<ComponentTs...> &query, Fn &&fn);
 
 protected:
     WorldBase *data_;

--- a/src/mw/device/include/madrona/context.hpp
+++ b/src/mw/device/include/madrona/context.hpp
@@ -50,6 +50,9 @@ public:
     inline WorldID worldID() const { return world_id_; }
 
     inline WorldBase & data() const { return *data_; }
+    
+    template <typename... ComponentTs>
+    inline void query(Query<ComponentTs>& query);
 
 protected:
     WorldBase *data_;

--- a/src/mw/device/include/madrona/context.hpp
+++ b/src/mw/device/include/madrona/context.hpp
@@ -53,7 +53,10 @@ public:
     inline WorldBase & data() const { return *data_; }
     
     template <typename... ComponentTs>
-    inline void query(Query<ComponentTs>& query);
+    inline Query<ComponentTs...> query();
+
+    template <typename... ComponentTs, typename Fn>
+    inline void iterateQuery(Query<ComponentTs...> &query, Fn&& fn);
 
 protected:
     WorldBase *data_;

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -91,7 +91,8 @@ template <typename... ComponentTs, typename Fn>
 inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
     mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(world_id_.idx, query.getSharedRef(), 
     [&](int32_t offset, auto ...raw_ptrs){
-            
+            // offset is a global offset computed from world offset and a count of 
+            // the current entity within the archetype table.
             cuda::std::tuple typed_ptrs {
                 (ComponentTs *)raw_ptrs
                 ...

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -89,10 +89,12 @@ inline Query<ComponentTs...> Context::query() {
     
 template <typename... ComponentTs, typename Fn>
 inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
-    mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(world_id_.idx, query.getSharedRef(), 
+    mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(
+        world_id_.idx,
+        query.getSharedRef(),
     [&](int32_t offset, auto ...raw_ptrs){
-            // offset is a global offset computed from world offset and a count of 
-            // the current entity within the archetype table.
+            // offset is a global offset computed from world offset and 
+            // a count of the current entity within the archetype table.
             cuda::std::tuple typed_ptrs {
                 (ComponentTs *)raw_ptrs
                 ...

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -96,7 +96,7 @@ inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
                 (ComponentTs *)raw_ptrs
                 ...
             };
-
+            
             std::apply([&](auto ...ptrs) {
                 fn(ptrs[offset] ...);
             }, typed_ptrs);

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -89,7 +89,19 @@ inline Query<ComponentTs...> Context::query() {
     
 template <typename... ComponentTs, typename Fn>
 inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
-    mwGPU::getStateManager()->iterateQuery(world_id_, query.getSharedRef(), fn);
+    mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(world_id_.idx, query.getSharedRef(), 
+    [&](auto ...raw_ptrs){
+            
+            cuda::std::tuple typed_ptrs {
+                (ComponentTs *)raw_ptrs
+                ...
+            };
+
+            std::apply([&](auto ...ptrs) {
+                fn(ptrs[0] ...);
+            }, typed_ptrs);
+
+    });
 }
 
 #if 0

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -83,27 +83,28 @@ inline void * Context::tmpAlloc(uint64_t num_bytes)
 }
 
 template <typename... ComponentTs>
-inline Query<ComponentTs...> Context::query() {
+inline Query<ComponentTs...> Context::query() 
+{
     return mwGPU::getStateManager()->query<ComponentTs...>();
 }
     
 template <typename... ComponentTs, typename Fn>
-inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
+inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) 
+{
     mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(
         world_id_.idx,
         query.getSharedRef(),
     [&](int32_t offset, auto ...raw_ptrs){
-            // offset is a global offset computed from world offset and 
-            // a count of the current entity within the archetype table.
-            cuda::std::tuple typed_ptrs {
-                (ComponentTs *)raw_ptrs
-                ...
-            };
-            
-            std::apply([&](auto ...ptrs) {
-                fn(ptrs[offset] ...);
-            }, typed_ptrs);
-
+        // offset is a global offset computed from world offset and 
+        // a count of the current entity within the archetype table.
+        cuda::std::tuple typed_ptrs {
+            (ComponentTs *)raw_ptrs
+            ...
+        };
+        
+        std::apply([&](auto ...ptrs) {
+            fn(ptrs[offset] ...);
+        }, typed_ptrs);
     });
 }
 

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -90,7 +90,7 @@ inline Query<ComponentTs...> Context::query() {
 template <typename... ComponentTs, typename Fn>
 inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
     mwGPU::getStateManager()->iterateQuery<sizeof...(ComponentTs)>(world_id_.idx, query.getSharedRef(), 
-    [&](auto ...raw_ptrs){
+    [&](int32_t offset, auto ...raw_ptrs){
             
             cuda::std::tuple typed_ptrs {
                 (ComponentTs *)raw_ptrs
@@ -98,7 +98,7 @@ inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
             };
 
             std::apply([&](auto ...ptrs) {
-                fn(ptrs[0] ...);
+                fn(ptrs[offset] ...);
             }, typed_ptrs);
 
     });

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -82,6 +82,11 @@ inline void * Context::tmpAlloc(uint64_t num_bytes)
     return mwGPU::TmpAllocator::get().alloc(num_bytes);
 }
 
+template <typename ComponentTs..., typename Fn>
+inline void Context::query(Query<ComponentTs...> &query, Fn&& fn) {
+    mwGPU::getStateManager()->iterateQuery(query, fn);
+}
+
 #if 0
 
 class Context {

--- a/src/mw/device/include/madrona/context.inl
+++ b/src/mw/device/include/madrona/context.inl
@@ -82,9 +82,14 @@ inline void * Context::tmpAlloc(uint64_t num_bytes)
     return mwGPU::TmpAllocator::get().alloc(num_bytes);
 }
 
-template <typename ComponentTs..., typename Fn>
-inline void Context::query(Query<ComponentTs...> &query, Fn&& fn) {
-    mwGPU::getStateManager()->iterateQuery(query, fn);
+template <typename... ComponentTs>
+inline Query<ComponentTs...> Context::query() {
+    return mwGPU::getStateManager()->query<ComponentTs...>();
+}
+    
+template <typename... ComponentTs, typename Fn>
+inline void Context::iterateQuery(Query<ComponentTs...> &query, Fn&& fn) {
+    mwGPU::getStateManager()->iterateQuery(world_id_, query.getSharedRef(), fn);
 }
 
 #if 0

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -221,6 +221,9 @@ private:
                    uint32_t num_components,
                    QueryRef *query_ref);
 
+    template <typename... ComponentTs, typename Fn>
+    void iterateQuery(uint32_t world_id, const Query<ComponentTs...>& query, Fn&& fn);
+
     Entity makeEntityNow(WorldID world_id, uint32_t archetype_id);
     Loc makeTemporary(WorldID world_id, uint32_t archetype_id);
 

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -79,6 +79,9 @@ public:
     template <int32_t num_components, typename Fn>
     void iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn);
 
+    template <int32_t num_components, typename Fn>
+    void iterateQuery(uint32_t world_id, QueryRef* query_ref, Fn&& fn);
+
     inline uint32_t numMatchingEntities(QueryRef *query_ref);
 
     template <typename ArchetypeT>
@@ -200,13 +203,14 @@ private:
     template <typename Fn, int32_t... Indices>
     void iterateArchetypesRawImpl(QueryRef *query_ref, Fn &&fn,
                                   std::integer_sequence<int32_t, Indices...>);
+    
+    template <typename Fn, int32_t... Indices>
+    void iterateQueryImpl(int32_t world_id, QueryRef *query_ref, Fn &&fn,
+                                  std::integer_sequence<int32_t, Indices...>);
 
     void makeQuery(const uint32_t *components,
                    uint32_t num_components,
                    QueryRef *query_ref);
-
-    template <typename Fn>
-    void iterateQuery(uint32_t world_id, QueryRef* query_ref, Fn&& fn);
 
     Entity makeEntityNow(WorldID world_id, uint32_t archetype_id);
     Loc makeTemporary(WorldID world_id, uint32_t archetype_id);

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -80,7 +80,7 @@ public:
     void iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn);
 
     template <int32_t num_components, typename Fn>
-    void iterateQuery(uint32_t world_id, QueryRef *query_ref, Fn&& fn);
+    void iterateQuery(uint32_t world_id, QueryRef *query_ref, Fn &&fn);
 
     inline uint32_t numMatchingEntities(QueryRef *query_ref);
 

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -132,6 +132,10 @@ public:
     inline int32_t * getArchetypeSortOffsets(uint32_t archetype_id);
 
     template <typename ArchetypeT>
+    int32_t * getArchetypeCounts();
+    inline int32_t * getArchetypeCounts(uint32_t archetype_id);
+
+    template <typename ArchetypeT>
     inline void setArchetypeSortOffsets(void *ptr);
 
     inline uint32_t getArchetypeColumnBytesPerRow(uint32_t archetype_id,
@@ -201,8 +205,8 @@ private:
                    uint32_t num_components,
                    QueryRef *query_ref);
 
-    template <typename... ComponentTs, typename Fn>
-    void iterateQuery(uint32_t world_id, const Query<ComponentTs...>& query, Fn&& fn);
+    template <typename Fn>
+    void iterateQuery(uint32_t world_id, QueryRef* query_ref, Fn&& fn);
 
     Entity makeEntityNow(WorldID world_id, uint32_t archetype_id);
     Loc makeTemporary(WorldID world_id, uint32_t archetype_id);

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -80,7 +80,7 @@ public:
     void iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn);
 
     template <int32_t num_components, typename Fn>
-    void iterateQuery(uint32_t world_id, QueryRef* query_ref, Fn&& fn);
+    void iterateQuery(uint32_t world_id, QueryRef *query_ref, Fn&& fn);
 
     inline uint32_t numMatchingEntities(QueryRef *query_ref);
 
@@ -130,17 +130,17 @@ public:
                                      int32_t column_idx);
 
     template <typename ArchetypeT>
-    int32_t * getArchetypeSortOffsets();
+    int32_t * getArchetypeWorldOffsets();
 
-    inline int32_t * getArchetypeSortOffsets(uint32_t archetype_id);
+    inline int32_t * getArchetypeWorldOffsets(uint32_t archetype_id);
 
     template <typename ArchetypeT>
-    int32_t * getArchetypeCounts();
+    int32_t * getArchetypeWorldCounts();
     
-    inline int32_t * getArchetypeCounts(uint32_t archetype_id);
+    inline int32_t * getArchetypeWorldCounts(uint32_t archetype_id);
 
     template <typename ArchetypeT>
-    inline void setArchetypeSortOffsets(void *ptr);
+    inline void setArchetypeWorldOffsets(void *ptr);
 
     inline uint32_t getArchetypeColumnBytesPerRow(uint32_t archetype_id,
                                                   int32_t column_idx);
@@ -232,8 +232,8 @@ private:
         ColumnMap columnLookup;
         
         // The size of this array corresponds to the number of worlds
-        int32_t *sortOffsets;
-        int32_t *counts;
+        int32_t *worldOffsets;
+        int32_t *worldCounts;
 
         bool needsSort;
     };

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -224,6 +224,7 @@ private:
         
         // The size of this array corresponds to the number of worlds
         int32_t *sortOffsets;
+        int32_t *counts;
 
         bool needsSort;
     };

--- a/src/mw/device/include/madrona/state.hpp
+++ b/src/mw/device/include/madrona/state.hpp
@@ -136,6 +136,7 @@ public:
 
     template <typename ArchetypeT>
     int32_t * getArchetypeCounts();
+    
     inline int32_t * getArchetypeCounts(uint32_t archetype_id);
 
     template <typename ArchetypeT>

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -180,9 +180,10 @@ void StateManager::iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn)
 }
 
 template<typename Fn, int32_t... Indices>
-void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, 
+void StateManager::iterateQueryImpl(int32_t world_id, QueryRef *query_ref, 
         Fn&& fn, 
-        std::integer_sequence<int32_t, Indices...>) {
+        std::integer_sequence<int32_t, Indices...>) 
+{
 
     
     uint32_t *query_values = &query_data_[query_ref->offset];
@@ -194,13 +195,13 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref,
 
         Table &tbl = archetypes_[archetype_idx]->tbl;
 
-        int32_t worldSortOffset = world_id == 0 ? 
-            0 : getArchetypeSortOffsets(archetype_idx)[world_id - 1];
+        int32_t worldOffset = 
+            getArchetypeWorldOffsets(archetype_idx)[world_id];
         int32_t worldArchetypeCount =
-            getArchetypeCounts(archetype_idx)[world_id];
+            getArchetypeWorldCounts(archetype_idx)[world_id];
 
         for (int i = 0; i < worldArchetypeCount; ++i) {
-            fn(worldSortOffset + i, tbl.columns[query_values[Indices]] ...);
+            fn(worldOffset + i, tbl.columns[query_values[Indices]] ...);
         }
 
         query_values += sizeof...(Indices);
@@ -208,8 +209,9 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref,
 }
 
 template<int32_t num_components, typename Fn>
-void StateManager::iterateQuery(uint32_t world_id, QueryRef* query_ref,
-    Fn&& fn) {
+void StateManager::iterateQuery(uint32_t world_id, QueryRef *query_ref,
+    Fn&& fn) 
+{
 
     using IndicesWrapper =
         std::make_integer_sequence<int32_t, num_components>;
@@ -356,31 +358,31 @@ void * StateManager::getArchetypeComponent(uint32_t archetype_id,
 }
 
 template <typename ArchetypeT>
-int32_t * StateManager::getArchetypeSortOffsets()
+int32_t * StateManager::getArchetypeWorldOffsets()
 {
     uint32_t archetype_id = TypeTracker::typeID<ArchetypeT>();
 
-    return getArchetypeSortOffsets(archetype_id);
+    return getArchetypeWorldOffsets(archetype_id);
 }
 
-int32_t * StateManager::getArchetypeSortOffsets(uint32_t archetype_id)
+int32_t * StateManager::getArchetypeWorldOffsets(uint32_t archetype_id)
 {
     auto &archetype = *archetypes_[archetype_id];
-    return archetype.sortOffsets;
+    return archetype.worldOffsets;
 }
 
 template <typename ArchetypeT>
-int32_t * StateManager::getArchetypeCounts()
+int32_t * StateManager::getArchetypeWorldCounts()
 {
     uint32_t archetype_id = TypeTracker::typeID<ArchetypeT>();
 
-    return getArchetypeCounts(archetype_id);
+    return getArchetypeWorldCounts(archetype_id);
 }
 
-int32_t * StateManager::getArchetypeCounts(uint32_t archetype_id)
+int32_t * StateManager::getArchetypeWorldCounts(uint32_t archetype_id)
 {
     auto &archetype = *archetypes_[archetype_id];
-    return archetype.counts;
+    return archetype.worldCounts;
 }
 
 int32_t StateManager::getArchetypeColumnIndex(uint32_t archetype_id,
@@ -412,11 +414,11 @@ void * StateManager::getArchetypeColumn(uint32_t archetype_id,
 }
 
 template <typename ArchetypeT>
-void StateManager::setArchetypeSortOffsets(void *ptr)
+void StateManager::setArchetypeWorldOffsets(void *ptr)
 {
     uint32_t archetype_id = TypeTracker::typeID<ArchetypeT>();
     auto &archetype = *archetypes_[archetype_id];
-    archetype.sortOffsets = (int32_t *)ptr;
+    archetype.worldOffsets = (int32_t *)ptr;
 }
 
 uint32_t StateManager::getArchetypeColumnBytesPerRow(uint32_t archetype_id,

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -192,8 +192,12 @@ template<typename Fn, int32_t... Indices>
 void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& fn, 
         std::integer_sequence<int32_t, Indices...>) {
 
+    
     uint32_t *query_values = &query_data_[query_ref->offset];
     int32_t num_archetypes = query_ref->numMatchingArchetypes;
+
+    // TODO: restore
+    printf("num_archteypes %d\n", num_archetypes);
 
     for (int i = 0; i < num_archetypes; i++) {
         uint32_t archetype_idx = *query_values;
@@ -201,16 +205,23 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& 
 
         Table &tbl = archetypes_[archetype_idx]->tbl;
 
-        int32_t worldSortOffset = getArchetypeSortOffsets(archetype_idx)[world_id];
-        int32_t worldCount = getArchetypeCounts(archetype_idx)[world_id];
+        int32_t worldSortOffset = world_id == 0 ? 0 : getArchetypeSortOffsets(archetype_idx)[world_id - 1];
+        int32_t worldArchetypeCount = getArchetypeCounts(archetype_idx)[world_id];
 
-        for (int i = 0; i < worldCount; ++i) {
-            fn(tbl.columns[query_values[Indices + ((worldSortOffset + i)
-            * getArchetypeColumnBytesPerRow(archetype_idx, query_values[Indices]) / sizeof(int32_t))]] ...);
+        // TODO: restore
+        printf("archetype_idx %d, world_id %d, worldSortOffset = %d, worldCount = %d\n", archetype_idx, world_id, worldSortOffset, worldArchetypeCount);
+
+        for (int i = 0; i < worldArchetypeCount; ++i) {
+            fn(worldSortOffset + i, tbl.columns[query_values[Indices]] ...);
         }
+
+
 
         query_values += sizeof...(Indices);
     }
+
+    //printf("Iterated all archetypes\n");
+
 }
 
 template<int32_t num_components, typename Fn>

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -180,7 +180,8 @@ void StateManager::iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn)
 }
 
 template<typename Fn, int32_t... Indices>
-void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& fn, 
+void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, 
+        Fn&& fn, 
         std::integer_sequence<int32_t, Indices...>) {
 
     
@@ -193,8 +194,10 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& 
 
         Table &tbl = archetypes_[archetype_idx]->tbl;
 
-        int32_t worldSortOffset = world_id == 0 ? 0 : getArchetypeSortOffsets(archetype_idx)[world_id - 1];
-        int32_t worldArchetypeCount = getArchetypeCounts(archetype_idx)[world_id];
+        int32_t worldSortOffset = world_id == 0 ? 
+            0 : getArchetypeSortOffsets(archetype_idx)[world_id - 1];
+        int32_t worldArchetypeCount =
+            getArchetypeCounts(archetype_idx)[world_id];
 
         for (int i = 0; i < worldArchetypeCount; ++i) {
             fn(worldSortOffset + i, tbl.columns[query_values[Indices]] ...);
@@ -205,7 +208,8 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& 
 }
 
 template<int32_t num_components, typename Fn>
-void StateManager::iterateQuery(uint32_t world_id, QueryRef* query_ref, Fn&& fn) {
+void StateManager::iterateQuery(uint32_t world_id, QueryRef* query_ref,
+    Fn&& fn) {
 
     using IndicesWrapper =
         std::make_integer_sequence<int32_t, num_components>;

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -197,7 +197,7 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& 
     int32_t num_archetypes = query_ref->numMatchingArchetypes;
 
     // TODO: restore
-    printf("num_archteypes %d\n", num_archetypes);
+    //printf("num_archteypes %d\n", num_archetypes);
 
     for (int i = 0; i < num_archetypes; i++) {
         uint32_t archetype_idx = *query_values;
@@ -209,7 +209,7 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef* query_ref, Fn&& 
         int32_t worldArchetypeCount = getArchetypeCounts(archetype_idx)[world_id];
 
         // TODO: restore
-        printf("archetype_idx %d, world_id %d, worldSortOffset = %d, worldCount = %d\n", archetype_idx, world_id, worldSortOffset, worldArchetypeCount);
+        //printf("archetype_idx %d, world_id %d, worldSortOffset = %d, worldCount = %d\n", archetype_idx, world_id, worldSortOffset, worldArchetypeCount);
 
         for (int i = 0; i < worldArchetypeCount; ++i) {
             fn(worldSortOffset + i, tbl.columns[query_values[Indices]] ...);

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -181,7 +181,7 @@ void StateManager::iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn)
 
 template<typename Fn, int32_t... Indices>
 void StateManager::iterateQueryImpl(int32_t world_id, QueryRef *query_ref, 
-        Fn&& fn, 
+        Fn &&fn, 
         std::integer_sequence<int32_t, Indices...>) 
 {
 
@@ -210,7 +210,7 @@ void StateManager::iterateQueryImpl(int32_t world_id, QueryRef *query_ref,
 
 template<int32_t num_components, typename Fn>
 void StateManager::iterateQuery(uint32_t world_id, QueryRef *query_ref,
-    Fn&& fn) 
+    Fn &&fn) 
 {
 
     using IndicesWrapper =

--- a/src/mw/device/include/madrona/state.inl
+++ b/src/mw/device/include/madrona/state.inl
@@ -138,6 +138,7 @@ Query<ComponentTs...> StateManager::query()
 
     QueryRef *ref = &Query<ComponentTs...>::ref_;
 
+    // ZM Deduplication, GPU side.
     if (ref->numReferences.load_acquire() == 0) {
         makeQuery(component_ids.data(), component_ids.size(), ref);
     }
@@ -178,6 +179,13 @@ void StateManager::iterateArchetypesRaw(QueryRef *query_ref, Fn &&fn)
 
     iterateArchetypesRawImpl(query_ref, std::forward<Fn>(fn),
                              IndicesWrapper());
+}
+
+template<typename Fn>
+void StateManager::iterateQuery(QueryRef* query_ref, Fn&& fn) {
+    // TODO: implement using the offsets from the sort.
+    // Does this also need to take in the WorldID?
+    // How do you get the sortOffsets from here? The QueryRef doesn't contain it. 
 }
 
 uint32_t StateManager::numMatchingEntities(QueryRef *query_ref)

--- a/src/mw/device/include/madrona/taskgraph.hpp
+++ b/src/mw/device/include/madrona/taskgraph.hpp
@@ -305,8 +305,8 @@ struct SortArchetypeNodeBase : NodeBase {
     void binScan(int32_t invocation_idx);
     void resizeTable(int32_t);
     void copyKeys(int32_t invocation_idx);
-    void computeOffsets(int32_t invocation_idx);
-    void computeCounts(int32_t invocation_idx);
+    void computeWorldOffsets(int32_t invocation_idx);
+    void computeWorldCounts(int32_t invocation_idx);
 
     static TaskGraph::NodeID addToGraph(
         TaskGraph::Builder &builder,
@@ -319,8 +319,8 @@ struct SortArchetypeNodeBase : NodeBase {
     int32_t sortColumnIndex;
     uint32_t *keysCol;
     int32_t numPasses;
-    int32_t *sortOffsets;
-    int32_t *counts;
+    int32_t *worldOffsets;
+    int32_t *worldCounts;
 
     TaskGraph::TypedDataID<OnesweepNode> onesweepNodes[4];
     TaskGraph::TypedDataID<RearrangeNode> firstRearrangePassData;

--- a/src/mw/device/include/madrona/taskgraph.hpp
+++ b/src/mw/device/include/madrona/taskgraph.hpp
@@ -296,7 +296,8 @@ struct SortArchetypeNodeBase : NodeBase {
                           int32_t col_idx,
                           uint32_t *keys_col,
                           int32_t num_passes,
-                          int32_t *sort_offsets);
+                          int32_t *sort_offsets,
+                          int32_t *counts);
 
     void sortSetup(int32_t);
     void zeroBins(int32_t invocation_idx);
@@ -319,6 +320,7 @@ struct SortArchetypeNodeBase : NodeBase {
     uint32_t *keysCol;
     int32_t numPasses;
     int32_t *sortOffsets;
+    int32_t *counts;
 
     TaskGraph::TypedDataID<OnesweepNode> onesweepNodes[4];
     TaskGraph::TypedDataID<RearrangeNode> firstRearrangePassData;

--- a/src/mw/device/include/madrona/taskgraph.hpp
+++ b/src/mw/device/include/madrona/taskgraph.hpp
@@ -305,6 +305,7 @@ struct SortArchetypeNodeBase : NodeBase {
     void resizeTable(int32_t);
     void copyKeys(int32_t invocation_idx);
     void computeOffsets(int32_t invocation_idx);
+    void computeCounts(int32_t invocation_idx);
 
     static TaskGraph::NodeID addToGraph(
         TaskGraph::Builder &builder,

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1386,7 +1386,7 @@ TaskGraph::NodeID SortArchetypeNodeBase::addToGraph(
 
     // Compute the world counts from the sort offsets.
     cur_task = builder.addNodeFn<&SortArchetypeNodeBase::computeWorldCounts>(
-        data_id, { cur_task }, setup, 0, 1);
+        data_id, {cur_task}, setup, 0, 1);
 
     int32_t num_columns = state_mgr->getArchetypeNumColumns(archetype_id);
 

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1210,9 +1210,7 @@ void SortArchetypeNodeBase::resizeTable(int32_t invocation_idx)
     int32_t numEntities = bins[(numPasses - 1) * 256 + 255];
     mwGPU::getStateManager()->resizeArchetype(archetypeID, numEntities);
     
-    if (invocation_idx == 0) {
-        numDynamicInvocations = numEntities;
-    }
+    numDynamicInvocations = numEntities;
 }
 
 void SortArchetypeNodeBase::copyKeys(int32_t invocation_idx)

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1263,12 +1263,8 @@ void SortArchetypeNodeBase::RearrangeNode::rearrangeEntities(int32_t invocation_
 
     Entity e = entities_staging[invocation_idx];
 
-    // ZM: Should be able to delete this conditional 
-    // after the resizeTables fix.
-    //if (worlds[invocation_idx].idx != -1) {
-    //    dst[invocation_idx] = e;
-    //    state_mgr->remapEntity(e, invocation_idx);
-    //}
+    dst[invocation_idx] = e;
+    state_mgr->remapEntity(e, invocation_idx);
 
     if (invocation_idx == 0) {
         numDynamicInvocations = 0;

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1227,8 +1227,8 @@ void SortArchetypeNodeBase::resizeTable(int32_t)
 {
     mwGPU::getStateManager()->resizeArchetype(
         archetypeID, bins[(numPasses - 1) * 256 + 255]);
-    //numDynamicInvocations = numRows;
-    numDynamicInvocations = bins[(numPasses - 1) * 256 + 255];
+    numDynamicInvocations = numRows;
+    //numDynamicInvocations = bins[(numPasses - 1) * 256 + 255];
 }
 
 void SortArchetypeNodeBase::copyKeys(int32_t invocation_idx)

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1242,7 +1242,7 @@ void SortArchetypeNodeBase::computeOffsets(int32_t invocation_idx)
     using namespace mwGPU;
 
         //HostPrint::log("keysCol[{}] = {}\n", invocation_idx, keysCol[invocation_idx]);
-        HostPrint::log("Offset Invocation {}\n", invocation_idx);
+        //HostPrint::log("Offset Invocation {}\n", invocation_idx);
 
     // TODO: restore
     //if (invocation_idx == 0) {
@@ -1273,7 +1273,7 @@ void SortArchetypeNodeBase::computeCounts(int32_t invocation_idx)
 
     counts[invocation_idx] = sortOffsets[invocation_idx] - (invocation_idx == 0 ? 0 : sortOffsets[invocation_idx - 1]);
 
-    HostPrint::log("counts[{}] = {}\n", invocation_idx, counts[invocation_idx]);
+    //HostPrint::log("counts[{}] = {}\n", invocation_idx, counts[invocation_idx]);
 }
 
 void SortArchetypeNodeBase::RearrangeNode::stageColumn(int32_t invocation_idx)
@@ -1411,11 +1411,6 @@ TaskGraph::NodeID SortArchetypeNodeBase::addToGraph(
         cur_task = builder.addNodeFn<&OnesweepNode::onesweep>(
             pass_data, {cur_task}, setup, 0, consts::numMegakernelThreads);
     }
-
-    // ZM: At this point, we are resizing the table, so the sort is assumed to have completed.
-    // ZM TODO: Add a simple node that uses the sort to compute the table offsets for different worlds.
-    // Right now, before resize, the sortOffset pointers are still in terms of 32 bit keys, so they
-    // can be used to compute the number of entities in each world.
 
     // FIXME this could be a fixed-size count
     if (world_sort) {

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1382,7 +1382,7 @@ TaskGraph::NodeID SortArchetypeNodeBase::addToGraph(
 
     // Compute the world sort offsets.
     cur_task = builder.addNodeFn<&SortArchetypeNodeBase::computeWorldOffsets>(
-            data_id, {cur_task}, setup, 0, 1);
+        data_id, {cur_task}, setup, 0, 1);
 
     // Compute the world counts from the sort offsets.
     cur_task = builder.addNodeFn<&SortArchetypeNodeBase::computeWorldCounts>(

--- a/src/mw/device/sort_archetype.cpp
+++ b/src/mw/device/sort_archetype.cpp
@@ -1227,8 +1227,8 @@ void SortArchetypeNodeBase::resizeTable(int32_t)
 {
     mwGPU::getStateManager()->resizeArchetype(
         archetypeID, bins[(numPasses - 1) * 256 + 255]);
-    numDynamicInvocations = numRows;
-    //numDynamicInvocations = bins[(numPasses - 1) * 256 + 255];
+    //numDynamicInvocations = numRows;
+    numDynamicInvocations = bins[(numPasses - 1) * 256 + 255];
 }
 
 void SortArchetypeNodeBase::copyKeys(int32_t invocation_idx)

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -167,6 +167,7 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
       tbl(),
       columnLookup(lookup_input, num_user_components),
       sortOffsets(nullptr),
+      counts(nullptr),
       needsSort(false)
 {
     using namespace mwGPU;
@@ -228,7 +229,7 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
         sortOffsets = (int32_t *)alloc->allocMemory(bytes);
     }
 
-    // Allocate space for the counst (one offset per world)
+    // Allocate space for the counts (one count per world)
     uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
     bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
     counts = (int32_t*)alloc->allocMemory(bytes);

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -226,12 +226,12 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
         uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
         bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
         sortOffsets = (int32_t *)alloc->allocMemory(bytes);
-
-        // Allocate space for the counst (one offset per world)
-        uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
-        bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
-        counts = (int32_t*)alloc->allocMemory(bytes);
     }
+
+    // Allocate space for the counst (one offset per world)
+    uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
+    bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
+    counts = (int32_t*)alloc->allocMemory(bytes);
 
     tbl.maxColumnSize = max_column_size;
 
@@ -298,6 +298,7 @@ void StateManager::makeQuery(const uint32_t *components,
     query_data_lock_.lock();
 
     if (query_ref->numMatchingArchetypes != 0xFFFF'FFFF) {
+        query_data_lock_.unlock();
         return;
     }
 

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -226,6 +226,11 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
         uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
         bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
         sortOffsets = (int32_t *)alloc->allocMemory(bytes);
+
+        // Allocate space for the counst (one offset per world)
+        uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
+        bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
+        counts = (int32_t*)alloc->allocMemory(bytes);
     }
 
     tbl.maxColumnSize = max_column_size;

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -225,13 +225,13 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
             ArchetypeFlags::ImportOffsets) {
         // Allocate space for the sorting offsets (one offset per world)
         uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
-        bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
+        bytes = alloc->roundUpReservation(bytes);
         sortOffsets = (int32_t *)alloc->allocMemory(bytes);
     }
 
     // Allocate space for the counts (one count per world)
     uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
-    bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
+    bytes = alloc->roundUpReservation(bytes);
     counts = (int32_t*)alloc->allocMemory(bytes);
 
     tbl.maxColumnSize = max_column_size;

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -197,7 +197,7 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
 
     { // Allocate space for the sorting offsets (one offset per world)
         uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
-        bytes = alloc->roundUpReservation(bytes);
+        bytes = alloc->roundUpReservation(bytes); // rounds up to a full page size, which for normal page sizes is definitely >= 256 worlds.
         sortOffsets = (int32_t *)alloc->allocMemory(bytes);
     }
 

--- a/src/mw/device/state.cpp
+++ b/src/mw/device/state.cpp
@@ -166,8 +166,8 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
       numUserComponents(num_user_components),
       tbl(),
       columnLookup(lookup_input, num_user_components),
-      sortOffsets(nullptr),
-      counts(nullptr),
+      worldOffsets(nullptr),
+      worldCounts(nullptr),
       needsSort(false)
 {
     using namespace mwGPU;
@@ -226,13 +226,13 @@ StateManager::ArchetypeStore::ArchetypeStore(uint32_t offset,
         // Allocate space for the sorting offsets (one offset per world)
         uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
         bytes = alloc->roundUpReservation(bytes);
-        sortOffsets = (int32_t *)alloc->allocMemory(bytes);
+        worldOffsets = (int32_t *)alloc->allocMemory(bytes);
     }
 
     // Allocate space for the counts (one count per world)
     uint64_t bytes = (uint64_t)sizeof(int32_t) * (uint64_t)num_worlds;
     bytes = alloc->roundUpReservation(bytes);
-    counts = (int32_t*)alloc->allocMemory(bytes);
+    worldCounts = (int32_t *)alloc->allocMemory(bytes);
 
     tbl.maxColumnSize = max_column_size;
 


### PR DESCRIPTION
Two specific things to highlight:
1. In SortArchetypeNodeBase::resizeTable, the numDynamicInvocations was previously being set to the numRows in the talble pre-resize, which could cause overflow if the table had shrunk.
2. The implementation pattern of StateManager::iterateQuery closes matches that of StateManager::iterateArchetypesRaw. The difference is that iterateArchetypes raw does not consider a world ID. I decided to keep them separate for now, but we may want to merge them to simplify the code.