### PR TITLE
Make glTF support optional in the importer.

### DIFF
--- a/src/importer/CMakeLists.txt
+++ b/src/importer/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MADRONA_GLTF_SUPPORT ON CACHE BOOL "")
+
 add_library(madrona_json STATIC
     ${MADRONA_INC_DIR}/json.hpp json.cpp
 )
@@ -11,9 +13,14 @@ target_link_libraries(madrona_json
 
 set(IMPORTER_SOURCES
     ${MADRONA_INC_DIR}/importer.hpp importer.cpp
-    gltf.hpp gltf.cpp
     obj.hpp obj.cpp
 )
+
+if (MADRONA_GLTF_SUPPORT)
+    list(APPEND IMPORTER_SOURCES
+         gltf.hpp gltf.cpp
+    )
+endif()
 
 if (MADRONA_USD_SUPPORT)
     list(APPEND IMPORTER_SOURCES
@@ -31,6 +38,12 @@ target_link_libraries(madrona_importer PRIVATE
     meshoptimizer
     fast_float
 )
+
+if (MADRONA_GLTF_SUPPORT)
+    target_compile_definitions(madrona_importer PRIVATE
+        MADRONA_GLTF_SUPPORT=1
+    )
+endif()
 
 if (MADRONA_USD_SUPPORT)
     target_link_libraries(madrona_importer PRIVATE

--- a/src/importer/importer.cpp
+++ b/src/importer/importer.cpp
@@ -7,7 +7,10 @@
 #include <meshoptimizer.h>
 
 #include "obj.hpp"
+
+#ifdef MADRONA_GLTF_SUPPORT
 #include "gltf.hpp"
+#endif
 
 #ifdef MADRONA_USD_SUPPORT
 #include "usd.hpp"
@@ -37,7 +40,9 @@ Optional<ImportedAssets> ImportedAssets::importFromDisk(
     };
 
     auto obj_loader = Optional<OBJLoader>::none();
+#ifdef MADRONA_GLTF_SUPPORT
     auto gltf_loader = Optional<GLTFLoader>::none();
+#endif
 #ifdef MADRONA_USD_SUPPORT
     auto usd_loader = Optional<USDLoader>::none();
 #endif
@@ -58,6 +63,7 @@ Optional<ImportedAssets> ImportedAssets::importFromDisk(
             }
 
             load_success = obj_loader->load(path, imported);
+#ifdef MADRONA_GLTF_SUPPORT
         } else if (extension == "gltf" || extension == "glb") {
             if (!gltf_loader.has_value()) {
                 gltf_loader.emplace(err_buf);
@@ -65,6 +71,11 @@ Optional<ImportedAssets> ImportedAssets::importFromDisk(
 
             load_success = gltf_loader->load(path, imported,
                                              one_object_per_asset);
+#else
+            load_success = false;
+            snprintf(err_buf.data(), err_buf.size(),
+                     "Madrona not compiled with glTF support");
+#endif
         } else if (extension == "usd" ||
                    extension == "usda" ||
                    extension == "usdc" ||

--- a/src/importer/importer.cpp
+++ b/src/importer/importer.cpp
@@ -63,8 +63,8 @@ Optional<ImportedAssets> ImportedAssets::importFromDisk(
             }
 
             load_success = obj_loader->load(path, imported);
-#ifdef MADRONA_GLTF_SUPPORT
         } else if (extension == "gltf" || extension == "glb") {
+#ifdef MADRONA_GLTF_SUPPORT
             if (!gltf_loader.has_value()) {
                 gltf_loader.emplace(err_buf);
             }


### PR DESCRIPTION
Compilation of gltf.cpp seems to take a long time, and there are use cases where this isn't needed.

Note that by default build configuration enables glTF support.