### PR TITLE
Only show full compilation message in "verbose_compile" mode

### DIFF
--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -853,7 +853,9 @@ static __attribute__((always_inline)) inline void dispatch(
     DynArray<HeapArray<char>> source_bytecodes(num_sources);
     printf("Compiling GPU engine code:\n");
     for (int64_t i = 0; i < num_sources; i++) {
-        printf("%s\n", sources[i]);
+        if verbose_compile {
+            printf("%s\n", sources[i]);
+        }
         auto [ptx, bytecode] = cu::jitCompileCPPFile(sources[i],
             compile_flags, num_compile_flags,
             fast_compile_flags, num_fast_compile_flags,


### PR DESCRIPTION
### Description

When a user builds the sim, the building message is quite verbose:

```bash
Compiling GPU engine code:
/home/emerge/gpudrive/external/madrona/src/mw/device/memory.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/state.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/crash.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/consts.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/taskgraph.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/taskgraph_utils.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/sort_archetype.cpp
/home/emerge/gpudrive/external/madrona/src/mw/device/host_print.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../common/hashmap.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../common/navmesh.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../core/base.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/physics.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/geo.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/xpbd.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/tgs.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/narrowpha
/home/emerge/gpudrive/src/level_gen.cpp(271): warning #177-D: function "gpudrive::createFloorPlane" was declared but never referenced
  static void createFloorPlane(Engine &ctx)
              ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"



se.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../physics/broadphase.cpp
/home/emerge/gpudrive/external/madrona/src/mw/../render/ecs_system.cpp
/home/emerge/gpudrive/src/sim.cpp
/home/emerge/gpudrive/src/level_gen.cpp
Initialization finished
```

I was wondering if we can make this a bit cleaner for Python users, only displaying the full message in "verbose_compile" mode. 


Thank you for considering this!
